### PR TITLE
Accept tagged template args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,24 +2,24 @@ import stringArgv from 'string-argv';
 
 const quote = (cmd: TemplateStringsArray, ...args: Array<string | number>) => {
   return cmd.reduce((acc, cur, i) => {
-    return acc + cur + (args[i] || '')
-  }, '')
+    return acc + cur + (args[i] || '');
+  }, '');
 }
 
 const exec = (c: string) => {
   return Bun.spawn(stringArgv(c));
 };
 
-const execWrapper = (cmd: TemplateStringsArray | string) => {
+const execWrapper = (cmd: TemplateStringsArray | string, ...args: Array<string | number>) => {
   if (typeof cmd === 'string') {
     return exec(cmd);
   } else {
-    return exec(quote(cmd));
+    return exec(quote(cmd, ...args));
   }
 };
 
-export const $ = async (cmd: TemplateStringsArray | string) => {
-  const proc = execWrapper(cmd);
+export const $ = async (cmd: TemplateStringsArray | string, ...args: Array<string | number>) => {
+  const proc = execWrapper(cmd, ...args);
   const text = await new Response(proc.stdout).text();
-  return text
+  return text;
 }


### PR DESCRIPTION
Hello!

I found a type error when using variables in tagged template literals.
This PR is to resolve this issue.

![image](https://github.com/wobsoriano/bnx/assets/954668/785e2977-e2dd-45ed-a73a-3ffd288c55c3)

It seems there have been changes in the following commit, and I'm afraid that there was a specific reason for making these changes:

https://github.com/wobsoriano/bnx/commit/f66236d6a4ef6b7c78d0b50d4d6372d927cddbcf